### PR TITLE
feat: 更新 CUDA 架构映射配置

### DIFF
--- a/setup_ops.py
+++ b/setup_ops.py
@@ -25,6 +25,16 @@ def set_cuda_archs():
     cuda_major, _ = paddle.version.cuda_version.split(".")
 
     if int(paddle.version.major) >= 3 and int(paddle.version.minor) >= 3:
+        ARCH_TO_CUDA_CAPABILITY = {
+            'Pascal': '6.0;6.1;6.2',
+            'Volta': '7.0;7.2',
+            'Turing': '7.5',
+            'Ampere': '8.0;8.6',
+            'Ada': '8.9',
+            'Hopper': '9.0',
+            'Blackwell': '10.0',
+        }
+
         if int(cuda_major) >= 13:
             paddle_known_gpu_archs = ['Turing','Ampere','Ada','Hopper','Blackwell']
         elif int(cuda_major) >= 12:
@@ -36,8 +46,8 @@ def set_cuda_archs():
         else:
             raise ValueError("Not support cuda version.")
 
-        os.environ["PADDLE_CUDA_ARCH_LIST"] = " ".join(
-            [str(arch) for arch in paddle_known_gpu_archs]
+        os.environ["PADDLE_CUDA_ARCH_LIST"] = ";".join(
+            [ARCH_TO_CUDA_CAPABILITY[arch] for arch in paddle_known_gpu_archs]
         )
     else:
         # compatible with paddle < 3.3.0


### PR DESCRIPTION
修改了 setup_ops.py 中针对 paddle >= 3.3  的安装逻辑，在 aistudio 中验证，修改后可以正常安装。

```shell
aistudio@jupyter-942478-10072559:~$ ipython
iPython 3.10.10 (main, Mar 21 2023, 18:45:11) [GCC 11.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.38.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import paddle
paddle.__versio/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py:712: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
  warnings.warn(warning_message)
in
In [2]: paddle.__version__
Out[2]: '3.3.0'
```

---

修改前，安装错误，关联 issue：https://github.com/PaddlePaddle/PaddleMaterials/issues/251 https://github.com/PFCCLab/paddle_scatter/issues/9

```shell
aistudio@jupyter-942478-10072559:~/PaddleMaterials/paddle_scatter$ pip install -v . --no-build-isolation
Using pip 26.0.1 from /home/aistudio/external-libraries/lib/python3.10/site-packages/pip (python 3.10)
Looking in indexes: http://mirrors.baidubce.com/pypi/simple/
Processing ./.
  Preparing metadata (pyproject.toml) ...   Running command Preparing metadata (pyproject.toml)
  /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py:712: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
    warnings.warn(warning_message)
  [2026-03-15 18:39:48,957] [    INFO] dist.py:985 - running dist_info
  [2026-03-15 18:39:48,968] [    INFO] dir_util.py:71 - creating /tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info
  [2026-03-15 18:39:48,978] [    INFO] egg_info.py:666 - writing /tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/PKG-INFO
  [2026-03-15 18:39:48,979] [    INFO] egg_info.py:289 - writing dependency_links to /tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/dependency_links.txt
  [2026-03-15 18:39:48,979] [    INFO] egg_info.py:289 - writing requirements to /tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/requires.txt
  [2026-03-15 18:39:48,979] [    INFO] egg_info.py:289 - writing top-level names to /tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/top_level.txt
  [2026-03-15 18:39:48,980] [    INFO] util.py:335 - writing manifest file '/tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/SOURCES.txt'
  [2026-03-15 18:39:49,068] [    INFO] egg_info.py:606 - adding license file 'LICENSE'
  [2026-03-15 18:39:49,070] [    INFO] util.py:335 - writing manifest file '/tmp/pip-modern-metadata-8m4opmb6/paddle_scatter.egg-info/SOURCES.txt'
  [2026-03-15 18:39:49,070] [    INFO] dist_info.py:111 - creating '/tmp/pip-modern-metadata-8m4opmb6/paddle_scatter-2.1.2.dist-info'
  /home/aistudio/external-libraries/lib/python3.10/site-packages/wheel/bdist_wheel.py:4: FutureWarning: The 'wheel' package is no longer the canonical location of the 'bdist_wheel' command, and will be removed in a future release. Please update to setuptools v70.1 or later which contains an integrated version of this command.
    warn(
done
Building wheels for collected packages: paddle-scatter
  Building wheel for paddle-scatter (pyproject.toml) ...   Running command Building wheel for paddle-scatter (pyproject.toml)
  /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py:712: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
    warnings.warn(warning_message)
  /home/aistudio/external-libraries/lib/python3.10/site-packages/wheel/bdist_wheel.py:4: FutureWarning: The 'wheel' package is no longer the canonical location of the 'bdist_wheel' command, and will be removed in a future release. Please update to setuptools v70.1 or later which contains an integrated version of this command.
    warn(
  [2026-03-15 18:39:51,621] [    INFO] dist.py:985 - running bdist_wheel
  [2026-03-15 18:39:51,673] [    INFO] dist.py:985 - running build
  [2026-03-15 18:39:51,673] [    INFO] dist.py:985 - running build_py
  [2026-03-15 18:39:51,697] [    INFO] _bdist_wheel.py:423 - installing to build/bdist.linux-x86_64/wheel
  [2026-03-15 18:39:51,697] [    INFO] dist.py:985 - running install
  /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py:712: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
    warnings.warn(warning_message)
  Traceback (most recent call last):
    File "/home/aistudio/PaddleMaterials/paddle_scatter/setup_ops.py", line 103, in <module>
      ext_modules=get_extensions(),
    File "/home/aistudio/PaddleMaterials/paddle_scatter/setup_ops.py", line 86, in get_extensions
      Extension(
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/cpp_extension.py", line 356, in CUDAExtension
      kwargs = normalize_extension_kwargs(kwargs, use_cuda=True)
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py", line 624, in normalize_extension_kwargs
      sm = [int(ss) for ss in s.split(".") if ss]
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/utils/cpp_extension/extension_utils.py", line 624, in <listcomp>
      sm = [int(ss) for ss in s.split(".") if ss]
  ValueError: invalid literal for int() with base 10: 'Pascal'
  Error running setup_ops.py: Command '['/opt/conda/envs/python35-paddle120-env/bin/python3.10', 'setup_ops.py', 'install']' returned non-zero exit status 1.
  Traceback (most recent call last):
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
      main()
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
      return _build_backend().build_wheel(
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/build_meta.py", line 434, in build_wheel
      return self._build_with_temp_dir(
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/build_meta.py", line 419, in _build_with_temp_dir
      self.run_setup()
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/build_meta.py", line 507, in run_setup
      super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in run_setup
      exec(code, locals())
    File "<string>", line 47, in <module>
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/__init__.py", line 103, in setup
      return distutils.core.setup(**attrs)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
      return run_commands(dist)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
      dist.run_commands()
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
      self.run_command(cmd)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/dist.py", line 989, in run_command
      super().run_command(command)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/wheel/_bdist_wheel.py", line 425, in run
      self.run_command("install")
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
      self.distribution.run_command(command)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/dist.py", line 989, in run_command
      super().run_command(command)
    File "/home/aistudio/external-libraries/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "<string>", line 36, in run
    File "<string>", line 25, in run_setup_ops
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/subprocess.py", line 369, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['/opt/conda/envs/python35-paddle120-env/bin/python3.10', 'setup_ops.py', 'install']' returned non-zero exit status 1.
  error: subprocess-exited-with-error
  
  × Building wheel for paddle-scatter (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> No available output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /opt/conda/envs/python35-paddle120-env/bin/python3.10 /home/aistudio/external-libraries/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /tmp/tmpg9pruhgy
  cwd: /home/aistudio/PaddleMaterials/paddle_scatter
error
  ERROR: Failed building wheel for paddle-scatter
Failed to build paddle-scatter
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
╰─> paddle-scatter
```